### PR TITLE
Check authorization status and location on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.0.3 Oct 9, 2018
+
+* fixed iOS threading issue
+
 ### v1.0.2 Oct 4, 2018
 
 * fixed Android plugin compile regression

--- a/ios/RNReaderSDKAuthorization.m
+++ b/ios/RNReaderSDKAuthorization.m
@@ -91,7 +91,9 @@ RCT_REMAP_METHOD(isAuthorized,
                      rejecter
                  : (RCTPromiseRejectBlock)reject)
 {
-    resolve(@(SQRDReaderSDK.sharedSDK.isAuthorized));
+    dispatch_async(dispatch_get_main_queue(), ^{
+        resolve(@(SQRDReaderSDK.sharedSDK.isAuthorized));
+    });
 }
 
 RCT_REMAP_METHOD(authorizedLocation,
@@ -100,11 +102,13 @@ RCT_REMAP_METHOD(authorizedLocation,
                      rejecter
                  : (RCTPromiseRejectBlock)reject)
 {
-    if (SQRDReaderSDK.sharedSDK.isAuthorized) {
-        resolve([SQRDReaderSDK.sharedSDK.authorizedLocation jsonDictionary]);
-    } else {
-        reject(RNReaderSDKUsageError, [RNReaderSDKErrorUtilities createNativeModuleError:RNReaderSDKRNAuthLocationNotAuthorized debugMessage:RNReaderSDKRNMessageAuthLocationNotAuthorized], nil);
-    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (SQRDReaderSDK.sharedSDK.isAuthorized) {
+            resolve([SQRDReaderSDK.sharedSDK.authorizedLocation jsonDictionary]);
+        } else {
+            reject(RNReaderSDKUsageError, [RNReaderSDKErrorUtilities createNativeModuleError:RNReaderSDKRNAuthLocationNotAuthorized debugMessage:RNReaderSDKRNMessageAuthLocationNotAuthorized], nil);
+        }
+    });
 }
 
 RCT_REMAP_METHOD(canDeauthorize,
@@ -113,7 +117,9 @@ RCT_REMAP_METHOD(canDeauthorize,
                      rejecter
                  : (RCTPromiseRejectBlock)reject)
 {
-    resolve(@(SQRDReaderSDK.sharedSDK.canDeauthorize));
+    dispatch_async(dispatch_get_main_queue(), ^{
+        resolve(@(SQRDReaderSDK.sharedSDK.canDeauthorize));
+    });
 }
 
 - (NSString *)getAuthorizationErrorCode:(NSInteger)nativeErrorCode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-square-reader-sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A React Native plugin for Square Reader SDK",
   "homepage": "https://github.com/square/react-native-square-reader-sdk",
   "repository": {


### PR DESCRIPTION
Authorization status is backed by CoreData, so accesses need to happen on the main thread.