### PR TITLE
Silent the reader sdk installation script in travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ matrix:
         - export PATH="$HOME/.yarn/bin:$PATH"
         - cd reader-sdk-react-native-quickstart
         - yarn
-        - cd ios && ruby <(curl https://connect.squareup.com/readersdk-installer) install --app-id $SQUARE_READER_SDK_APPLICATION_ID --repo-password $SQUARE_READER_SDK_REPOSITORY_PASSWORD
+        - cd ios && ruby <(curl https://connect.squareup.com/readersdk-installer) install --app-id $SQUARE_READER_SDK_APPLICATION_ID --repo-password $SQUARE_READER_SDK_REPOSITORY_PASSWORD --version 1.0.1 > /dev/null
       script:
         - xcodebuild clean build -project RNReaderSDKSample.xcodeproj -scheme RNReaderSDKSample -destination "platform=iOS Simulator,OS=11.1,name=iPhone 8" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO -quiet


### PR DESCRIPTION
The log from reader sdk installation script is too big and burst the travis console memory, make the script quiet to solve the problem