### PR TITLE
Minimum update to Reader SDK 1.1.* without new features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,6 @@ matrix:
         - export PATH="$HOME/.yarn/bin:$PATH"
         - cd reader-sdk-react-native-quickstart
         - yarn
-        - cd ios && ruby <(curl https://connect.squareup.com/readersdk-installer) install --app-id $SQUARE_READER_SDK_APPLICATION_ID --repo-password $SQUARE_READER_SDK_REPOSITORY_PASSWORD --version 1.0.1 > /dev/null
+        - cd ios && ruby <(curl https://connect.squareup.com/readersdk-installer) install --app-id $SQUARE_READER_SDK_APPLICATION_ID --repo-password $SQUARE_READER_SDK_REPOSITORY_PASSWORD --version 1.1.1 > /dev/null
       script:
         - xcodebuild clean build -project RNReaderSDKSample.xcodeproj -scheme RNReaderSDKSample -destination "platform=iOS Simulator,OS=11.1,name=iPhone 8" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=NO -quiet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 ## Changelog
 
+### v1.1.0 Mar 3rd, 2019
+
+* remove `alwaysRequireSignature` and add `collectSignature` to checkout configuration.
+* bump the minimum dependency to Reader SDK 1.1.1(iOS)/1.1.3(Android).
+* this change **does NOT** include all new features introduced in Reader SDK 1.1.* such as **Store customer card**, see reader SDK [Change Log](https://docs.connect.squareup.com/changelog/mobile-logs/2019-02-13) for details.
+
 ### v1.0.3 Oct 9, 2018
 
-* fixed iOS threading issue
+* fixed iOS threading issue.
 
 ### v1.0.2 Oct 4, 2018
 
-* fixed Android plugin compile regression
+* fixed Android plugin compile regression.
 
 ### v1.0.1 Oct 4, 2018
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This repo contains a React Native plugin for Square [Reader SDK]. Reader SDK for
 React Native supports the following native Reader SDK versions:
 
-  * iOS: version 1.0.1
-  * Android: 1.0.3
+  * iOS: version 1.1.1
+  * Android: 1.1.3
 
 ## In this repo
 
@@ -20,6 +20,7 @@ In addition to the standard React Native directories, this repo includes:
 
 ### Android
 
+* minSdkVersion is API 21 (Lollipop 5.0) or higher.
 * Android SDK platform: API 26 (Oreo, 8.0).
 * Android SDK build tools: 26.0.3
 * Android Gradle Plugin: 3.0.0 or greater.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,14 +31,15 @@ buildscript {
 apply plugin: 'com.android.library'
 
 def DEFAULT_PLAY_SERVICES_BASE_VERSION = '12.0.1'
+def MIN_READER_SDK_VERSION = '1.1.3'
 
 android {
     compileSdkVersion 26
     buildToolsVersion "26.0.3"
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 25
+        minSdkVersion 21
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
@@ -66,7 +67,7 @@ repositories {
 }
 
 dependencies {
-    def readerSdkVersion = '1.0.4'
+    def readerSdkVersion = rootProject.hasProperty('readerSdkVersion') ? rootProject.readerSdkVersion : MIN_READER_SDK_VERSION
     def playServicesBaseVersion = rootProject.hasProperty('googlePlayServiceVersion') ? rootProject.googlePlayServiceVersion : DEFAULT_PLAY_SERVICES_BASE_VERSION
     implementation 'com.facebook.react:react-native:+'
     implementation "com.google.android.gms:play-services-base:$playServicesBaseVersion"

--- a/android/src/main/java/com/squareup/sdk/reader/react/internal/converter/CardConverter.java
+++ b/android/src/main/java/com/squareup/sdk/reader/react/internal/converter/CardConverter.java
@@ -55,6 +55,9 @@ class CardConverter {
                 case SQUARE_GIFT_CARD:
                     brandStringMap.put(brand, "SQUARE_GIFT_CARD");
                     break;
+                case EFTPOS:
+                    brandStringMap.put(brand, "EFTPOS");
+                    break;
                 case OTHER_BRAND:
                     brandStringMap.put(brand, "OTHER_BRAND");
                     break;

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -102,21 +102,15 @@ installing Reader SDK for Android, see the [Reader SDK Android Setup Guide] at
     }
     ```
 1. Reader SDK and its dependencies contain more than 65k methods, so your build
-   script must enable Multidex. If your `minSdkVersion` is less than **21**, you
-   also need to include the `multidex` dependency:
+   script must enable Multidex.
+
     ```gradle
     android {
       defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
         multiDexEnabled true
       }
-    }
-
-    dependencies {
-      // Add this dependency if your minSdkVersion < 21
-      implementation 'com.android.support:multidex:1.0.3'
-      // ...
     }
     ```
 1. Configure the Multidex options:
@@ -328,7 +322,7 @@ const checkoutParams = {
   },
   // Optional for all following configuration
   skipReceipt: false,
-  alwaysRequireSignature: true,
+  collectSignature: true,
   allowSplitTender: false,
   note: 'ReaderSDKSample Transaction',
   tipSettings: {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -360,7 +360,7 @@ Field                  | Type                                              | Des
 ---------------------- | ------------------------------------------------- | -----------------
 amountMoney            | [Money](#money)                                   | **REQUIRED**. The total payment amount.
 skipReceipt            | boolean                                           | Indicates that the digital receipt options screen should not be displayed during checkout. Default: `false`
-alwaysRequireSignature | boolean                                           | Indicates that signature collection is required during checkout for all card transactions. Default: `true`
+collectSignature       | boolean                                           | Indicates that signature collection is required during checkout. When false, the signature screen will never be displayed; when true, it will always be used. Default: `false`
 allowSplitTender       | boolean                                           | Indicates that multiple payment methods are allowed. Default: `false`
 note                   | String                                            | A note to display on digital receipts and in the [Square Dashboard]. Default: `undefined` (empty note)
 tipSettings            | [TipSettings](#tipsettings)                       | Settings that configure the tipping behavior of the checkout flow. Default: `undefined` (Tip screen disabled)
@@ -375,7 +375,7 @@ additionalPaymentTypes | [AdditionalPaymentType](#additionalpaymenttype)[] | Val
     "currencyCode": "USD"
   },
   "skipReceipt": false,
-  "alwaysRequireSignature": true,
+  "collectSignature": true,
   "allowSplitTender": false,
   "note": "Payment for dogsitting",
   "tipSettings": {

--- a/ios/Converters/SQRDCard+RNReaderSDKAdditions.m
+++ b/ios/Converters/SQRDCard+RNReaderSDKAdditions.m
@@ -62,6 +62,9 @@ limitations under the License.
         case SQRDCardBrandSquareGiftCard:
             result = @"SQUARE_GIFT_CARD";
             break;
+        case SQRDCardBrandEftpos:
+            result = @"EFTPOS";
+            break;
         case SQRDCardBrandOtherBrand:
             result = @"OTHER_BRAND";
             break;

--- a/ios/Converters/SQRDLocation+RNReaderSDKAdditions.m
+++ b/ios/Converters/SQRDLocation+RNReaderSDKAdditions.m
@@ -26,7 +26,7 @@ limitations under the License.
     jsLocationResult[@"locationId"] = self.locationID;
     jsLocationResult[@"name"] = self.name;
     jsLocationResult[@"businessName"] = self.businessName;
-    jsLocationResult[@"isCardProcessingActivated"] = [NSNumber numberWithBool:self.isCardProcessingActivated == YES];
+    jsLocationResult[@"isCardProcessingActivated"] = @(self.isCardProcessingActivated);
     jsLocationResult[@"minimumCardPaymentAmountMoney"] = [self.minimumCardPaymentAmountMoney jsonDictionary];
     jsLocationResult[@"maximumCardPaymentAmountMoney"] = [self.maximumCardPaymentAmountMoney jsonDictionary];
     jsLocationResult[@"currencyCode"] = SQRDCurrencyCodeGetISOCurrencyCode(self.currencyCode);

--- a/ios/RNReaderSDKCheckout.m
+++ b/ios/RNReaderSDKCheckout.m
@@ -81,13 +81,13 @@ RCT_REMAP_METHOD(startCheckout,
             checkoutParams.note = jsParams[@"note"];
         }
         if (jsParams[@"skipReceipt"]) {
-            checkoutParams.skipReceipt = ([jsParams[@"skipReceipt"] boolValue] == YES);
+            checkoutParams.skipReceipt = [jsParams[@"skipReceipt"] boolValue];
         }
-        if (jsParams[@"alwaysRequireSignature"]) {
-            checkoutParams.alwaysRequireSignature = ([jsParams[@"alwaysRequireSignature"] boolValue] == YES);
+        if (jsParams[@"collectSignature"]) {
+            checkoutParams.collectSignature = [jsParams[@"collectSignature"] boolValue];
         }
         if (jsParams[@"allowSplitTender"]) {
-            checkoutParams.allowSplitTender = ([jsParams[@"allowSplitTender"] boolValue] == YES);
+            checkoutParams.allowSplitTender = [jsParams[@"allowSplitTender"] boolValue];
         }
         if (jsParams[@"tipSettings"]) {
             SQRDTipSettings *tipSettings = [self buildTipSettings:jsParams[@"tipSettings"]];
@@ -146,8 +146,8 @@ RCT_REMAP_METHOD(startCheckout,
         *errorMsg = @"'skipReceipt' is not a boolean";
         return NO;
     }
-    if (jsCheckoutParameters[@"alwaysRequireSignature"] && ![jsCheckoutParameters[@"alwaysRequireSignature"] isKindOfClass:[NSNumber class]]) {
-        *errorMsg = @"'alwaysRequireSignature' is not a boolean";
+    if (jsCheckoutParameters[@"collectSignature"] && ![jsCheckoutParameters[@"collectSignature"] isKindOfClass:[NSNumber class]]) {
+        *errorMsg = @"'collectSignature' is not a boolean";
         return NO;
     }
     if (jsCheckoutParameters[@"allowSplitTender"] && ![jsCheckoutParameters[@"allowSplitTender"] isKindOfClass:[NSNumber class]]) {
@@ -202,10 +202,10 @@ RCT_REMAP_METHOD(startCheckout,
 {
     SQRDTipSettings *tipSettings = [SQRDTipSettings alloc];
     if (tipSettingConfig[@"showCustomTipField"]) {
-        tipSettings.showCustomTipField = ([tipSettingConfig[@"showCustomTipField"] boolValue] == YES);
+        tipSettings.showCustomTipField = [tipSettingConfig[@"showCustomTipField"] boolValue];
     }
     if (tipSettingConfig[@"showSeparateTipScreen"]) {
-        tipSettings.showSeparateTipScreen = ([tipSettingConfig[@"showSeparateTipScreen"] boolValue] == YES);
+        tipSettings.showSeparateTipScreen = [tipSettingConfig[@"showSeparateTipScreen"] boolValue];
     }
     if (tipSettingConfig[@"tipPercentages"]) {
         NSMutableArray *tipPercentages = [[NSMutableArray alloc] init];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-square-reader-sdk",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A React Native plugin for Square Reader SDK",
   "homepage": "https://github.com/square/react-native-square-reader-sdk",
   "repository": {

--- a/reader-sdk-react-native-quickstart/android/app/build.gradle
+++ b/reader-sdk-react-native-quickstart/android/app/build.gradle
@@ -94,7 +94,6 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     api "com.facebook.react:react-native:+"  // From node_modules
-    implementation 'com.android.support:multidex:1.0.3' // Add this dependency if your minSdkVersion < 21
 }
 
 // Run this once to be able to run the application with BUCK

--- a/reader-sdk-react-native-quickstart/android/app/src/main/java/com/rnreadersdksample/MainApplication.java
+++ b/reader-sdk-react-native-quickstart/android/app/src/main/java/com/rnreadersdksample/MainApplication.java
@@ -16,9 +16,6 @@ limitations under the License.
 package com.rnreadersdksample;
 
 import android.app.Application;
-import android.content.Context;
-import android.support.multidex.MultiDex;
-
 import com.facebook.react.ReactApplication;
 import com.squareup.sdk.reader.ReaderSdk;
 import com.wix.RNCameraKit.RNCameraKitPackage;
@@ -64,11 +61,5 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     ReaderSdk.initialize(this);
-  }
-
-  @Override protected void attachBaseContext(Context base) {
-    super.attachBaseContext(base);
-    // Required if minSdkVersion < 21
-    MultiDex.install(this);
   }
 }

--- a/reader-sdk-react-native-quickstart/android/build.gradle
+++ b/reader-sdk-react-native-quickstart/android/build.gradle
@@ -47,8 +47,11 @@ allprojects {
 
 ext {
     buildToolsVersion = "26.0.3"
-    minSdkVersion = 19
+    minSdkVersion = 21
     compileSdkVersion = 26
-    targetSdkVersion = 25
+    targetSdkVersion = 26
     supportLibVersion = "26.0.2"
+    // Override the reader sdk version with the this parameter
+    // make sure the version is above min version 1.1.3
+    readerSdkVersion = "1.1.3"
 }

--- a/reader-sdk-react-native-quickstart/app/screens/CheckoutScreen.js
+++ b/reader-sdk-react-native-quickstart/app/screens/CheckoutScreen.js
@@ -60,7 +60,7 @@ class CheckoutScreen extends Component {
       },
       // Optional for all following configuration
       skipReceipt: false,
-      alwaysRequireSignature: true,
+      collectSignature: true,
       allowSplitTender: false,
       note: 'Hello 💳 💰 World!',
       tipSettings: {


### PR DESCRIPTION
This is a minimum update that enable plugin to use Reader SDK 1.1.*, the update include:

1. remove `alwaysRequireSignature` and `collectSignature` to adapt the checkout configuration change
1. bump the minimum dependency  to Reader SDK 1.1.1(iOS)/1.1.3(Android)
1. Remove Mutidex dependency from quick start. 
1. Some update to the build configuration

fix #44 and partially fix #43 