### PR TITLE
Allows SquareReaderSDK.framework to be added to a root sub dir

### DIFF
--- a/ios/RNReaderSdk.xcodeproj/project.pbxproj
+++ b/ios/RNReaderSdk.xcodeproj/project.pbxproj
@@ -294,7 +294,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"$(PROJECT_DIR)/../../../ios/",
+					"$(PROJECT_DIR)/../../../ios/**",
 					"$(PROJECT_DIR)/../../../",
 					"$(PROJECT_DIR)/../reader-sdk-react-native-quickstart/ios/",
 				);
@@ -317,7 +317,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"$(PROJECT_DIR)/../../../ios/",
+					"$(PROJECT_DIR)/../../../ios/**",
 					"$(PROJECT_DIR)/../../../",
 					"$(PROJECT_DIR)/../reader-sdk-react-native-quickstart/ios/",
 				);


### PR DESCRIPTION
## Summary

 so that we no longer face `Module 'SquareReaderSDK' not found` when moving the framework file in a subdirectory.

## Related issues

Fix https://github.com/square/react-native-square-reader-sdk/issues/49

## Changelog

Made the `/../../../ios` framework search path recursive

## Test Plan

Move the `SquareReaderSDK.framework` directory inside a folder called `frameworks` in your {react-native root}/ios project dir. Before that change you'd see a `Module 'SquareReaderSDK' not found` when trying to build the project.
Not anymore.