### PR TITLE
Make framework search paths search recursively

### DIFF
--- a/RNReaderSDK.podspec
+++ b/RNReaderSDK.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'ios/**/*.h'
   s.requires_arc = true
   s.frameworks   = 'SquareReaderSDK'
-  s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '$(PROJECT_DIR)/../' }
+  s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '$(PROJECT_DIR)/../**' }
 
   s.dependency "React"
 end


### PR DESCRIPTION
This allows a user to store the framework file on a sub dir, instead of just the root dir.
