### PR TITLE
Xiao/update quick start for 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### v1.2.1 May 29, 2019
 
-* Update to be compatible with Android Reader SDK 1.3.0. (No delay capture)
+* Update to be compatible with Android Reader SDK 1.3.0,
+  but the new feature "delay capture" hasn't been supported yet.
 
 ### v1.2.0 Mar 28, 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.2.1 May 29, 2019
+
+* Update to be compatible with Android Reader SDK 1.3.0. (No delay capture)
+
 ### v1.2.0 Mar 28, 2019
 
 * Support Android Reader SDK 1.2.1.

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ In addition to the standard React Native directories, this repo includes:
 ### Android
 
 * minSdkVersion is API 21 (Lollipop 5.0) or higher.
-* Android SDK platform: API 26 (Oreo, 8.0).
+* Android SDK platform: API 28 (Pie, 9.0) or lower.
 * Android SDK build tools: 26.0.3
 * Android Gradle Plugin: 3.0.0 or greater.
-* Support library: 26.0.2
-* Google Play Services: 12.0.1
+* Support library: 28.0.0
+* Google Play Services: 16.0.1
 * Google APIs Intel x86 Atom_64 System Image
 
 ### iOS
@@ -39,7 +39,7 @@ In addition to the standard React Native directories, this repo includes:
 
 ## Reader SDK requirements and limitations
 
-* Reader SDK is only available for accounts based in the United States.
+* Reader SDK is **only** available for accounts based in the **United States**.
   Authorization requests for accounts based outside the United States return an
   error.
 * Reader SDK may not be used for unattended terminals. Using Reader SDK to

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,30 +16,31 @@ limitations under the License.
 
 buildscript {
     repositories {
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
     }
 }
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_PLAY_SERVICES_BASE_VERSION = '12.0.1'
+def DEFAULT_PLAY_SERVICES_BASE_VERSION = '16.0.1'
 def READER_SDK_VERSION = '[1.2.1, 2.0)'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.3"
+    compileSdkVersion 28
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -128,6 +128,7 @@ installing Reader SDK for Android, see the [Reader SDK Android Setup Guide] at
     }
     ```
 1. Configure the Multidex options:
+
     ```gradle
     android {
       // ...
@@ -142,23 +143,6 @@ installing Reader SDK for Android, see the [Reader SDK Android Setup Guide] at
       // ...
     }
     ```
-
-1. Configure the Multidex options:
-    ```gradle
-    android {
-      // ...
-      dexOptions {
-        // Ensures incremental builds remain fast
-        preDexLibraries true
-        // Required to build with Reader SDK
-        jumboMode true
-        // Required to build with Reader SDK
-        keepRuntimeAnnotatedClasses false
-      }
-      // ...
-    }
-    ```
-
 1. Open `MainApplication.java` and add code to Import and initialize Reader SDK:
     ```java
     import com.squareup.sdk.reader.ReaderSdk;

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -107,11 +107,24 @@ installing Reader SDK for Android, see the [Reader SDK Android Setup Guide] at
 
     ```gradle
     android {
+      // ...
       defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 28
         multiDexEnabled true
       }
+    }
+    ```
+1. Enable compileOptions `JavaVersion.VERSION_1_8`.
+
+    ```gradle
+    android {
+      // ...
+      compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+      }
+      // ...
     }
     ```
 1. Configure the Multidex options:
@@ -129,28 +142,38 @@ installing Reader SDK for Android, see the [Reader SDK Android Setup Guide] at
       // ...
     }
     ```
-1. Extend the Android Application class (`android.app.Application`) and add code
-   to Import and initialize Reader SDK:
+
+1. Configure the Multidex options:
+    ```gradle
+    android {
+      // ...
+      dexOptions {
+        // Ensures incremental builds remain fast
+        preDexLibraries true
+        // Required to build with Reader SDK
+        jumboMode true
+        // Required to build with Reader SDK
+        keepRuntimeAnnotatedClasses false
+      }
+      // ...
+    }
+    ```
+
+1. Open `MainApplication.java` and add code to Import and initialize Reader SDK:
     ```java
     import com.squareup.sdk.reader.ReaderSdk;
 
-    public class ExampleApplication extends Application {
+    public class MainApplication extends Application {
 
       @Override public void onCreate() {
         super.onCreate();
         ReaderSdk.initialize(this);
       }
-
-      @Override protected void attachBaseContext(Context base) {
-        super.attachBaseContext(base);
-        // Required if minSdkVersion < 21
-        MultiDex.install(this);
-      }
     }
     ```
 
 ---
-**Note:** Reader SDK is guaranteed to work with support library version 26.0.2. If you want to use a higher version of support library, you will need to update build.gradle to add the targeted version of the required libraries (e.g. design, support-v4, recyclerview-v7).
+**Note:** Reader SDK is guaranteed to work with support library version 28.0.0. If you want to use a higher version of support library, you will need to update build.gradle to add the targeted version of the required libraries (e.g. design, support-v4, recyclerview-v7).
 
 If you use a higher version of the support library, we recommend establishing a resolution strategy in build.gradle to ensure all support library dependencies are on the same version. For example:
 
@@ -163,8 +186,8 @@ configurations.all {
         && details.requested.name != 'multidex'
         && details.requested.name != 'multidex-instrumentation') {
         // Force the version that works for you.
-        // Square has tested ReaderSDK with 26.0.2
-        details.useVersion '26.0.2'
+        // Square has tested ReaderSDK with 28.0.0
+        details.useVersion '28.0.0'
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-square-reader-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A React Native plugin for Square Reader SDK",
   "homepage": "https://github.com/square/react-native-square-reader-sdk",
   "repository": {

--- a/reader-sdk-react-native-quickstart/android/app/build.gradle
+++ b/reader-sdk-react-native-quickstart/android/app/build.gradle
@@ -43,6 +43,11 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "com.rnreadersdksample"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -122,7 +127,7 @@ configurations.all {
                     && details.requested.name != 'multidex'
                     && details.requested.name != 'multidex-instrumentation') {
                 // Force the version that works for you.
-                // Square has tested ReaderSDK with 26.0.2
+                // Square has tested ReaderSDK with 28.0.0
                 details.useVersion rootProject.ext.supportLibVersion
             }
         }

--- a/reader-sdk-react-native-quickstart/android/build.gradle
+++ b/reader-sdk-react-native-quickstart/android/build.gradle
@@ -50,5 +50,5 @@ ext {
     supportLibVersion = "28.0.0"
     // Override the reader sdk version with the this parameter
     // make sure the version is above min version 1.2.1
-    readerSdkVersion = "1.3.0"
+    readerSdkVersion = "[1.2.1, 2.0)"
 }

--- a/reader-sdk-react-native-quickstart/android/build.gradle
+++ b/reader-sdk-react-native-quickstart/android/build.gradle
@@ -17,10 +17,6 @@ limitations under the License.
 buildscript {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
         google()
     }
     dependencies {
@@ -51,8 +47,8 @@ ext {
     minSdkVersion = 26
     compileSdkVersion = 28
     targetSdkVersion = 28
-    supportLibVersion = "26.0.2"
+    supportLibVersion = "28.0.0"
     // Override the reader sdk version with the this parameter
     // make sure the version is above min version 1.2.1
-    readerSdkVersion = "[1.2.1, 2.0)"
+    readerSdkVersion = "1.3.0"
 }

--- a/reader-sdk-react-native-quickstart/package.json
+++ b/reader-sdk-react-native-quickstart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reader-sdk-react-native-quickstart",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/react-native-square-reader-sdk/blob/master/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Android Reader SDK 1.3.0 upgrade requires app's build.gradle update, otherwise the project crash when launch.

## Related issues

N/A

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/react-native-square-reader-sdk/blob/master/CHANGELOG.md for an example. -->

* Update to be compatible with Android Reader SDK 1.3.0. (No delay capture)
* Update docs to add necessary steps to configure Android Reader SDK 1.3.0 and update the version for library/SDK requirements.

## Test Plan

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->
manually tested with quick start app.