### PR TITLE
Exposes isAuthorizationInProgress

### DIFF
--- a/android/src/main/java/com/squareup/sdk/reader/react/AuthorizationModule.java
+++ b/android/src/main/java/com/squareup/sdk/reader/react/AuthorizationModule.java
@@ -72,6 +72,11 @@ class AuthorizationModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void isAuthorizationInProgress(Promise promise) {
+        promise.resolve(ReaderSdk.authorizationManager().getAuthorizationState().isAuthorizationInProgress());
+    }
+
+    @ReactMethod
     public void authorizedLocation(Promise promise) {
         if (ReaderSdk.authorizationManager().getAuthorizationState().isAuthorized()) {
             LocationConverter locationConverter = new LocationConverter();

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -25,6 +25,7 @@ Method                                                    | Return Object       
 [deauthorizeAsync](#deauthorizeasync)                     | void                              | Deauthorizes Reader SDK.
 [getAuthorizedLocationAsync](#getauthorizedlocationasync) | [Location](#location)             | Returns the currently authorized location
 [isAuthorizedAsync](#isauthorizedasync)                   | boolean                           | Verifies Reader SDK is currently authorized for payment collection.
+[isAuthorizationInProgressAsync](#isAuthorizationInProgressAsync)                   | boolean                           | Verifies Reader SDK is currently authorizing.
 [startCheckoutAsync](#startcheckoutasync)                 | [CheckoutResult](#checkoutresult) | Begins the checkout workflow.
 [startReaderSettingsAsync](#startreadersettingsasync)     | void                              | Starts the Reader settings flow for connecting Square Reader
 
@@ -182,6 +183,31 @@ if (await isAuthorizedAsync()) {
 
 } else {
   Alert.alert('Unable to take payments', 'Reader SDK is not authorized.');
+}
+```
+
+
+---
+
+### isAuthorizationInProgressAsync
+
+Used to determine if Reader SDK is currently authorizing.
+
+* **On success**: returns `true` if the sdk is currently authorizing, `false` otherwise.
+* **On failure**: throws [`USAGE_ERROR`](#e1).
+
+
+#### Example usage
+
+```javascript
+import { isAuthorizationInProgressAsync } from 'react-native-square-reader-sdk';
+...
+if (await isAuthorizationInProgressAsync()) {
+
+  // The reader is currently authorizing, don't try to authorize again
+
+} else {
+  Alert.alert('Unable to authorize again', 'Reader SDK is already authorizing.');
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,14 @@ export async function isAuthorizedAsync() {
   }
 }
 
+export async function isAuthorizationInProgressAsync() {
+  try {
+    return await RNReaderSDKAuthorization.isAuthorizationInProgress();
+  } catch (ex) {
+    throw createReaderSDKError(ex);
+  }
+}
+
 export async function canDeauthorizeAsync() {
   try {
     return await RNReaderSDKAuthorization.canDeauthorize();

--- a/ios/RNReaderSDKAuthorization.m
+++ b/ios/RNReaderSDKAuthorization.m
@@ -94,6 +94,15 @@ RCT_REMAP_METHOD(isAuthorized,
     });
 }
 
+RCT_EXPORT_METHOD(isAuthorizationInProgress
+                  : (RCTPromiseResolveBlock)resolve andRejecter
+                  : (RCTPromiseRejectBlock)reject)
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        resolve(@(SQRDReaderSDK.sharedSDK.isAuthorizationInProgress));
+    });
+}
+
 RCT_REMAP_METHOD(authorizedLocation,
                  authorizedLocationWithResolver
                  : (RCTPromiseResolveBlock)resolve

--- a/ios/RNReaderSDKAuthorization.m
+++ b/ios/RNReaderSDKAuthorization.m
@@ -94,9 +94,11 @@ RCT_REMAP_METHOD(isAuthorized,
     });
 }
 
-RCT_EXPORT_METHOD(isAuthorizationInProgress
-                  : (RCTPromiseResolveBlock)resolve andRejecter
-                  : (RCTPromiseRejectBlock)reject)
+RCT_REMAP_METHOD(isAuthorizationInProgress,
+                 isAuthorizationInProgressWithResolver
+                 : (RCTPromiseResolveBlock)resolve
+                 rejecter
+                 : (RCTPromiseRejectBlock)reject)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         resolve(@(SQRDReaderSDK.sharedSDK.isAuthorizationInProgress));


### PR DESCRIPTION
## Summary

isLogged in is not enough to figure wether we're supposed to log in or not. Therefore we need the `isAuthorizationInProgress` flag to do that, otherwise we run the risk of receiving a `authorization_already_authorized` error.

This PR exposes this API feature.