### PR TITLE
[Docs] Make it easier to install the Reader SDK

### DIFF
--- a/reader-sdk-react-native-quickstart/README.md
+++ b/reader-sdk-react-native-quickstart/README.md
@@ -66,8 +66,8 @@ problems building the sample app.
    [root README]for this repo:
     ```bash
     ruby <(curl https://connect.squareup.com/readersdk-installer) install \
-    --app-id YOUR_SQUARE_READER_APP_ID                                    \
-    --repo-password YOUR_SQUARE_READER_REPOSITORY_PASSWORD
+    --app-id $YOUR_SQUARE_READER_APP_ID                                    \
+    --repo-password $YOUR_SQUARE_READER_REPOSITORY_PASSWORD
     ```
 4. Run the React Native project from the `reader-sdk-react-native-quickstart`
    project folder:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/react-native-square-reader-sdk/blob/master/CONTRIBUTING.md
-->

## Summary

It's a minor change that hopefully doesn't set too many people back, but just adding the dollar sign to the beginning of the variables here would enable people to copy their credentials in the terminal first and then just [copy and paste the install command](https://user-images.githubusercontent.com/3363867/66924455-ab841a00-eff8-11e9-9e31-f8e49f3c2746.png).


 To go one step further, it'd be really nice to have the [Reader SDK page](https://developer.squareup.com/apps/sq0idp-CuoyOR5d1K9x4UwqYMfc-Q/reader-sdk) include [these changes](https://user-images.githubusercontent.com/3363867/66924366-78da2180-eff8-11e9-8346-6374ec6046f0.png).

Here is what installation history would then look like:
```bash
➜  ios git:(master) ✗ YOUR_SQUARE_READER_APP_ID=sq0idp...
➜  ios git:(master) ✗ YOUR_SQUARE_READER_REPOSITORY_PASSWORD=x6yflacmlhjja....
➜  ios git:(master) ✗ ruby <(curl https://connect.squareup.com/readersdk-installer) install \
    --app-id $YOUR_SQUARE_READER_APP_ID                                    \
    --repo-password $YOUR_SQUARE_READER_REPOSITORY_PASSWORD
```

For those in the know about the bash trick, the time savings is nice, and for those not in the know, it should not have any effect.

Thanks for the great SDK, can't wait to get started building some cool stuff.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/react-native-square-reader-sdk/blob/master/CHANGELOG.md for an example. -->

* Updated installation instructions for the Reader SDK

## Test Plan

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->