### PR TITLE
Update get-started.md

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -230,6 +230,9 @@ installing Reader SDK for iOS, see the [Reader SDK iOS Setup Guide] at
    * `NSMicrophoneUsageDescription` : "This app integrates with Square for card
      processing. To swipe magnetic cards via the headphone jack, Square requires
      access to the microphone."
+   * `NSBluetoothAlwaysUsageDescription` : "This app integrates with Square
+     for card processing. Square uses Bluetooth to connect your device to
+     compatible hardware."
    * `NSBluetoothPeripheralUsageDescription` : This app integrates with Square
      for card processing. Square uses Bluetooth to connect your device to
      compatible hardware.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/react-native-square-reader-sdk/blob/master/CONTRIBUTING.md
-->

## Summary
App was crashing on iOS 13 device due to privacy violation.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issues
[SOLVED: authorizeAsync(authCode) crashes iPad, but not simulator. #101](https://github.com/square/react-native-square-reader-sdk/issues/101)
## Fix
Add `NSBluetoothAlwaysUsageDescription` to list of device permissions. 

## Changelog
Updated `docs/getting-started.md` to include `NSBluetoothAlwaysUsageDescription` in list of device permission keys.

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/react-native-square-reader-sdk/blob/master/CHANGELOG.md for an example. -->
<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->