### PR TITLE
add missing "NSBluetoothAlwaysUsageDescription" to ios quick start

### DIFF
--- a/reader-sdk-react-native-quickstart/android/app/build.gradle
+++ b/reader-sdk-react-native-quickstart/android/app/build.gradle
@@ -147,6 +147,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    packagingOptions {
+        exclude("META-INF/*.kotlin_module") 
+    }
+
     defaultConfig {
         applicationId "com.rnreadersdksample"
         minSdkVersion rootProject.ext.minSdkVersion

--- a/reader-sdk-react-native-quickstart/ios/RNReaderSDKSample/Info.plist
+++ b/reader-sdk-react-native-quickstart/ios/RNReaderSDKSample/Info.plist
@@ -35,6 +35,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>This application integrates with Square for card processing. Square uses Bluetooth to connect your device to compatible hardware.</string>
 	<key>NSBluetoothPeripheralUsageDescription	</key>
 	<string>This app integrates with Square for card processing. Square uses Bluetooth to connect your device to compatible hardware.
 </string>
@@ -42,7 +44,7 @@
 	<string>This app integrates with Square for card processing. Upload your account logo, feature photo and product images with the photos stored on your mobile device.
 </string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-		<string>This app integrates with Square for card processing. To protect buyers and sellers, Square requires your location to process payments.</string>
+	<string>This app integrates with Square for card processing. To protect buyers and sellers, Square requires your location to process payments.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This app integrates with Square for card processing. To swipe magnetic cards via the headphone jack, Square requires access to the microphone.</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/react-native-square-reader-sdk/blob/master/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

NSBluetoothAlwaysUsageDescription is missing from "Info.plist" and the quick start app stuck after auth

## Related issues

Fix #

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/react-native-square-reader-sdk/blob/master/CHANGELOG.md for an example. -->

* Add  `NSBluetoothAlwaysUsageDescription` and the description to the project

## Test Plan

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->