### PR TITLE
Fix exception when tipSettings is undefined.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ export default function ValidateCheckoutParameters(checkoutParams:CheckoutParams
     throw new Error(JSON.stringify(paramError));
   }
 
-  if (hasNonNullProperty(checkoutParams.tipSettings, 'tipSettings')) {
+  if (hasNonNullProperty(checkoutParams, 'tipSettings')) {
     // check tipSettings
     const tipSettings:TipSettings = checkoutParams.tipSettings;
     if (hasNonNullProperty(tipSettings, 'showCustomTipField') && typeof tipSettings.showCustomTipField !== 'boolean') {


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/react-native-square-reader-sdk/blob/master/CONTRIBUTING.md
-->

## Summary

Fixes an exception `TypeError: undefined is not an object (evaluating 'Object.prototype.hasOwnProperty.call(t,o)’)` when `tipSettings` is not defined. `tipSettings` is supposed to be optional, and suppresses the tip screen when undefined, but a regression was introduced via #148 that forced it to be required and show a tip screen or the unhandled exception would result.

## Related issues

Addresses regression in #148, outlined in [this PR review](https://github.com/square/react-native-square-reader-sdk/pull/148#pullrequestreview-1130398115) (reviewed post release)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/react-native-square-reader-sdk/blob/master/CHANGELOG.md for an example. -->

* Fix exception when `tipSettings` is undefined on `CheckoutParameter`

## Test Plan

The bug this fixes is reproducible by trying to start a checkout with `tipSettings: undefined` (tip screen suppressed). After this fix, the checkout flow will function properly.