### PR TITLE
Fix crash when tipSettings is not provided in checkoutParams.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ export default function ValidateCheckoutParameters(checkoutParams:CheckoutParams
     throw new Error(JSON.stringify(paramError));
   }
 
-  if (hasNonNullProperty(checkoutParams.tipSettings, 'tipSettings')) {
+  if (hasNonNullProperty(checkoutParams, 'tipSettings')) {
     // check tipSettings
     const tipSettings:TipSettings = checkoutParams.tipSettings;
     if (hasNonNullProperty(tipSettings, 'showCustomTipField') && typeof tipSettings.showCustomTipField !== 'boolean') {


### PR DESCRIPTION
## Summary

In recent versions of the Square Reader SDK, failing to provide tipSettings in checkoutParams (which you must do if you want to disable tipping for a transaction) causes an exception to be thrown from the Reader SDK's JavaScript code.

## Related issues

None I could find.

## Changelog

- Fixed exception thrown when disabling tipping.

## Test Plan

Initiate a transaction with tipping disabled by removing tipSettings parameter. An exception is no longer thrown.