### PR TITLE
Fix typescript type for manual card entry payment type

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -678,7 +678,7 @@ tipPercentages        | Integer[] | A list of up to 3 non-negative integers from
 Payment types accepted during the Reader SDK checkout flow in addition to
 payments via Square Readers:
 
-* `card`  - Manually typed-in card payments.
+* `manual_card_entry`  - Manually typed-in card payments.
 * `cash`  - Cash payments. Useful for testing.
 * `other` - Check, third-party gift cards, and other payment types.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,7 +93,7 @@ declare module "react-native-square-reader-sdk" {
 		tipPercentages?: number[]
 	}
 
-	export type AdditionalPaymentType = "card" | "cash" | "other"
+	export type AdditionalPaymentType = "manual_card_entry" | "cash" | "other"
 
 	export interface Tender {
 		/** Details about the tender. Only set for card tenders. */


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/react-native-square-reader-sdk/blob/master/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The current type definitions mention that `card` is a valid `AdditionalPaymentType` - however, when checking out the native code of the Reader SDK, the native SDKs expect `manual_card_entry` to be used. This PR fixes the type definition so the correct string is used.

## Related issues

Fix #

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/react-native-square-reader-sdk/blob/master/CHANGELOG.md for an example. -->

* adjust the type of the `card` `AdditionalPaymentType` to be `manual_card_entry` in accordance to the usage in the native SDKs

## Test Plan

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->

N/A