### PR TITLE
Fix crash in iOS Sample App

### DIFF
--- a/reader-sdk-react-native-quickstart/ios/RNReaderSDKSample.xcodeproj/project.pbxproj
+++ b/reader-sdk-react-native-quickstart/ios/RNReaderSDKSample.xcodeproj/project.pbxproj
@@ -158,8 +158,8 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				980F11B223028AF00040C218 /* Embed Frameworks */,
-				113D56FE269F89D7004B6DD6 /* ShellScript */,
 				41A3709AB7CD46250E2E1AD7 /* [CP] Copy Pods Resources */,
+				113D56FE269F89D7004B6DD6 /* Run Script */,
 			);
 			buildRules = (
 			);
@@ -229,22 +229,23 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
-		113D56FE269F89D7004B6DD6 /* ShellScript */ = {
+		113D56FE269F89D7004B6DD6 /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 8;
+			buildActionMask = 12;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
 			);
+			name = "Run Script";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 1;
+			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nFRAMEWORKS=\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\n\"${FRAMEWORKS}/SquareReaderSDK.framework/setup\"\n";
+			shellScript = "FRAMEWORKS=\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\n\"${FRAMEWORKS}/SquareReaderSDK.framework/setup\"\n";
 		};
 		3F4688564D78681EB770F2F8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Summary

- Quick start app was crashing on launch because the setup script wasn't being run in all cases. See https://github.com/square/react-native-square-reader-sdk/issues/213.

## Solution
- Removed check to only run script on install builds

