### PR TITLE
Update documentation for Objective-C AppDelegate

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -241,6 +241,7 @@ installing Reader SDK for iOS, see [Reader SDK iOS Setup Guide].
 
 1. Update the `func application` method in your app
    delegate to initialize Reader SDK:
+   * Swift - Update AppDelegate.swift as follows:
     ```Swift
     import Foundation
     import SquareReaderSDK
@@ -259,6 +260,24 @@ installing Reader SDK for iOS, see [Reader SDK iOS Setup Guide].
    }
 
     ```
+   * Objective-C - Update AppDelegate.mm as follows:
+    ```objective-c
+    @import SquareReaderSDK;
+    @implementation AppDelegate
+
+    - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+    {
+      //...
+      [SQRDReaderSDK initializeWithApplicationLaunchOptions:launchOptions];
+
+      return YES;
+    }
+
+    ```
+    Note: In order to import correctly, your project will need to enable modules for Objective-C and Objective-C++. To do this you must:
+    1. Add the flags `-fmodules` and `-fcxx-modules` to `Other C++ Flags` in your targets build settings.
+    2. Update the build setting property `Allow Non-modular Includes in Framework Modules` to `Yes`.
+
 
 You will also need to add code to your React Native project to request device and
 microphone permissions. See the React Native Reader SDK Quick Start Sample App

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -241,7 +241,7 @@ installing Reader SDK for iOS, see [Reader SDK iOS Setup Guide].
 
 1. Update the `func application` method in your app
    delegate to initialize Reader SDK:
-   * Swift - Update AppDelegate.swift as follows:
+   * Swift - Update `AppDelegate.swift` as follows:
     ```Swift
     import Foundation
     import SquareReaderSDK
@@ -257,10 +257,9 @@ installing Reader SDK for iOS, see [Reader SDK iOS Setup Guide].
      SQRDReaderSDK.initialize(applicationLaunchOptions: launchOptions)
      return true
     }
-   }
 
     ```
-   * Objective-C - Update AppDelegate.mm as follows:
+   * Objective-C - Update `AppDelegate.mm` as follows:
     ```objective-c
     @import SquareReaderSDK;
     @implementation AppDelegate
@@ -268,13 +267,14 @@ installing Reader SDK for iOS, see [Reader SDK iOS Setup Guide].
     - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
     {
       //...
+
       [SQRDReaderSDK initializeWithApplicationLaunchOptions:launchOptions];
 
       return YES;
     }
 
     ```
-    Note: In order to import correctly, your project will need to enable modules for Objective-C and Objective-C++. To do this you must:
+    Note for Objective-C: In order to import correctly, your project will need to enable modules for Objective-C and Objective-C++. To do this you must:
     1. Add the flags `-fmodules` and `-fcxx-modules` to `Other C++ Flags` in your targets build settings.
     2. Update the build setting property `Allow Non-modular Includes in Framework Modules` to `Yes`.
 


### PR DESCRIPTION
## Summary

Documentation for importing the SDK was out of date.
- Added a section on how to properly import Square Reader SDK if developer's AppDelegate is in Objective-C. 
- Added a note for compiler flags needed to import correctly using Objective-C