### PR TITLE
Add a github action to publish to NPM.js.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,4 +75,4 @@ jobs:
         run: ruby <(curl https://connect.squareup.com/readersdk-installer) install --app-id ${{secrets.SQUARE_READER_SDK_APPLICATION_ID}} --repo-password ${{secrets.SQUARE_READER_SDK_REPOSITORY_PASSWORD}} --version 1.6.1 > /dev/null
       - name: Build iOS (debug)
         working-directory: ./reader-sdk-react-native-quickstart/ios
-        run: xcodebuild -workspace RNReaderSDKSample.xcworkspace -configuration Debug -scheme RNReaderSDKSample -destination "platform=iOS Simulator,OS=18.2,name=iPhone 16"
+        run: xcodebuild -workspace RNReaderSDKSample.xcworkspace -configuration Debug -scheme RNReaderSDKSample -destination generic/platform=iOS

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,4 +75,4 @@ jobs:
         run: ruby <(curl https://connect.squareup.com/readersdk-installer) install --app-id ${{secrets.SQUARE_READER_SDK_APPLICATION_ID}} --repo-password ${{secrets.SQUARE_READER_SDK_REPOSITORY_PASSWORD}} --version 1.6.1 > /dev/null
       - name: Build iOS (debug)
         working-directory: ./reader-sdk-react-native-quickstart/ios
-        run: xcodebuild -workspace RNReaderSDKSample.xcworkspace -configuration Debug -scheme RNReaderSDKSample -destination "platform=iOS Simulator,OS=16.2,name=iPhone 14"
+        run: xcodebuild -workspace RNReaderSDKSample.xcworkspace -configuration Debug -scheme RNReaderSDKSample -destination "platform=iOS Simulator,OS=18.2,name=iPhone 16"

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,29 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: react-native-square-reader-sdk
+
+on:
+  push:
+    tags:
+    # matches 'v{{version}}', e.g. v1.4.3
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm i
+      - run: npm pack    
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "react-native-square-reader-sdk",
-      "version": "1.4.3",
+      "version": "1.7.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "babel-eslint": "^10.1.0",


### PR DESCRIPTION
Add a github action to publish to NPM.js.
Fix package-lock.json was outdated.

## Summary

Add a new action in .github to publish to NPM.JS. This still needs some configuration in our repo, but it's the first step. 

## Related issues

N/A

## Changelog

Added npm-publish-github-packages.yml.
Modified package-lock.json.

## Test Plan

Run the steps in the GH action in my computer with the `--dry-run` option